### PR TITLE
feat(metrics): add data point reclaim/reuse for observable instruments

### DIFF
--- a/src/OpenTelemetry/Metrics/AggregatorStore.cs
+++ b/src/OpenTelemetry/Metrics/AggregatorStore.cs
@@ -41,7 +41,7 @@ namespace OpenTelemetry.Metrics
         private readonly UpdateLongDelegate updateLongCallback;
         private readonly UpdateDoubleDelegate updateDoubleCallback;
         private readonly int maxMetricPoints;
-        private readonly MetricStreamIdentity id; // FIXME: This should be only what we need to keep the constructor simple.
+        private readonly MetricStreamIdentity id;
         private ConcurrentQueue<int> free;
         private int metricPointIndex = 0;
         private int batchSize = 0;

--- a/src/OpenTelemetry/Metrics/Metric.cs
+++ b/src/OpenTelemetry/Metrics/Metric.cs
@@ -126,7 +126,7 @@ namespace OpenTelemetry.Metrics
                 throw new NotSupportedException($"Unsupported Instrument Type: {instrumentIdentity.InstrumentType.FullName}");
             }
 
-            this.aggStore = new AggregatorStore(instrumentIdentity.InstrumentName, aggType, temporality, maxMetricPointsPerMetricStream, histogramBounds ?? DefaultHistogramBounds, tagKeysInteresting);
+            this.aggStore = new AggregatorStore(instrumentIdentity, aggType, temporality, maxMetricPointsPerMetricStream, histogramBounds ?? DefaultHistogramBounds, tagKeysInteresting);
             this.Temporality = temporality;
             this.InstrumentDisposed = false;
         }

--- a/src/OpenTelemetry/Metrics/MetricPoint.cs
+++ b/src/OpenTelemetry/Metrics/MetricPoint.cs
@@ -92,8 +92,6 @@ namespace OpenTelemetry.Metrics
         /// </summary>
         public readonly DateTimeOffset EndTime => this.aggregatorStore.EndTimeInclusive;
 
-        public void MarkAsStale() => MetricPointStatus = MetricPointStatus.Stale; // for now.
-
         internal MetricPointStatus MetricPointStatus
         {
             [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -270,6 +268,9 @@ namespace OpenTelemetry.Metrics
             copy.histogramBuckets = this.histogramBuckets?.Copy();
             return copy;
         }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        internal void MarkAsStale() => this.MetricPointStatus = MetricPointStatus.Stale; // for now.
 
         internal void Update(long number)
         {
@@ -661,7 +662,10 @@ namespace OpenTelemetry.Metrics
             // in a subsequent collect cycle, the metric point can be reclaimed.
             // This is safe because observable gauges are always queried synchronously during the
             // Collect cycle. This cannot be used for regular instruments.
-            if (isObserved) this.MetricPointStatus = MetricPointStatus.Stale;
+            if (isObserved)
+            {
+                this.MarkAsStale();
+            }
         }
 
         private void UpdateHistogram(double number)

--- a/src/OpenTelemetry/Metrics/MetricPointStatus.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointStatus.cs
@@ -29,5 +29,10 @@ namespace OpenTelemetry.Metrics
         /// Collect will move it to <see cref="NoCollectPending"/>.
         /// </summary>
         CollectPending,
+
+        /// <summary>
+        /// The <see cref="MetricPoint"/> is stale and can be reclaimed.
+        /// </summary>
+        Stale,
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricPointStatus.cs
+++ b/src/OpenTelemetry/Metrics/MetricPointStatus.cs
@@ -34,5 +34,10 @@ namespace OpenTelemetry.Metrics
         /// The <see cref="MetricPoint"/> is stale and can be reclaimed.
         /// </summary>
         Stale,
+
+        /// <summary>
+        /// The <see cref="MetricPoint"/> is available for re-use.
+        /// </summary>
+        Free,
     }
 }

--- a/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
+++ b/src/OpenTelemetry/Metrics/MetricStreamIdentity.cs
@@ -31,6 +31,7 @@ namespace OpenTelemetry.Metrics
             this.Unit = instrument.Unit ?? string.Empty;
             this.Description = metricStreamConfiguration?.Description ?? instrument.Description ?? string.Empty;
             this.InstrumentType = instrument.GetType();
+            this.IsObservable = instrument.IsObservable; // Used to determine how to mark points as stale.
             this.ViewId = metricStreamConfiguration?.ViewId;
             this.MetricStreamName = $"{this.MeterName}.{this.MeterVersion}.{this.InstrumentName}";
             this.TagKeys = metricStreamConfiguration?.CopiedTagKeys;
@@ -89,6 +90,8 @@ namespace OpenTelemetry.Metrics
         public string MeterVersion { get; }
 
         public string InstrumentName { get; }
+
+        public bool IsObservable { get; }
 
         public string Unit { get; }
 

--- a/test/Benchmarks/Metrics/DataPointReclaimBenchmarks.cs
+++ b/test/Benchmarks/Metrics/DataPointReclaimBenchmarks.cs
@@ -1,0 +1,102 @@
+// <copyright file="DataPointReclaimBenchmarks.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+
+using System.Diagnostics.Metrics;
+using BenchmarkDotNet.Attributes;
+using OpenTelemetry;
+using OpenTelemetry.Metrics;
+using OpenTelemetry.Tests;
+
+/*
+// * Summary *
+
+BenchmarkDotNet=v0.13.3, OS=Windows 10 (10.0.19045.3208)
+11th Gen Intel Core i7-11800H 2.30GHz, 1 CPU, 16 logical and 8 physical cores
+.NET SDK=7.0.203
+  [Host]     : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+  DefaultJob : .NET 7.0.5 (7.0.523.17405), X64 RyuJIT AVX2
+
+
+|                              Method | Reclaim |     Mean |    Error |   StdDev |
+|------------------------------------ |-------- |---------:|---------:|---------:|
+| ObservableInstrumentReclaimOverhead |   False | 35.34 us | 0.193 us | 0.161 us |
+| ObservableInstrumentReclaimOverhead |    True | 38.28 us | 0.274 us | 0.229 us |
+*/
+
+namespace Benchmarks.Metrics
+{
+    public class DataPointReclaimBenchmarks
+    {
+        private const int ReclaimRange = 10; // [-N, N] range of measurements to go over the measurement limit. (Up to 2 * ReclaimRange can be reclaimed per iteration)
+        private const int ReclaimOverage = ReclaimRange; // How many points to allow over the limit.
+        private const int NumberOfMeasurements = 500; // Maximum number of measurements
+
+        private readonly Random random = new();
+
+        private ObservableGauge<long> gauge;
+        private Measurement<long>[] measurements;
+        private MeterProvider provider;
+        private Meter meter;
+
+        [Params(false, true)]
+        public bool Reclaim { get; set; }
+
+        [GlobalSetup]
+        public void Setup()
+        {
+            this.meter = new Meter(Utils.GetCurrentMethodName());
+
+            this.measurements = new Measurement<long>[NumberOfMeasurements + ReclaimOverage];
+            for (int i = 0; i < this.measurements.Length; ++i)
+            {
+                this.measurements[i] = new Measurement<long>(1, new[] { new KeyValuePair<string, object>("n", i) });
+            }
+
+            List<Metric> exportedItems = new();
+            this.provider = Sdk.CreateMeterProviderBuilder()
+                .AddMeter(this.meter.Name) // All instruments from this meter are enabled.
+                .SetMaxMetricPointsPerMetricStream(NumberOfMeasurements + 1) // Add an extra metric point to account for 0-tag point.
+                .AddInMemoryExporter(exportedItems, metricReaderOptions =>
+                {
+                    metricReaderOptions.PeriodicExportingMetricReaderOptions.ExportIntervalMilliseconds = (int)TimeSpan.FromDays(5).TotalMilliseconds; // Use Forceflush
+                    metricReaderOptions.TemporalityPreference = MetricReaderTemporalityPreference.Cumulative; // Doesn't matter for gauges.
+                })
+                .Build();
+
+            this.gauge = this.meter.CreateObservableGauge("gauge", SelectDatapoints);
+
+            IEnumerable<Measurement<long>> SelectDatapoints()
+            {
+                var delta = this.random.Next(-ReclaimRange, ReclaimRange); // Always call random even for no reclaim.
+
+                return this.measurements.Take(this.Reclaim ? NumberOfMeasurements + delta : NumberOfMeasurements);
+            }
+        }
+
+        [GlobalCleanup]
+        public void Cleanup()
+        {
+            this.meter?.Dispose();
+            this.provider?.Dispose();
+        }
+
+        [Benchmark]
+        public void ObservableInstrumentReclaimOverhead()
+        {
+            this.provider.ForceFlush(); // Force Collect cycle.
+        }
+    }
+}

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/OpenTelemetry.Extensions.Propagators.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/OpenTelemetry.Extensions.Propagators.Tests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">net7.0;net6.0;net462</TargetFrameworks>
+    <!-- FIXME(alxbl): Do not build net462 on Mac/*NIX-->
+    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">net7.0;net6.0</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) != ''">$(TARGET_FRAMEWORK)</TargetFrameworks>
 
     <!-- this is temporary. will remove in future PR. -->

--- a/test/OpenTelemetry.Extensions.Propagators.Tests/OpenTelemetry.Extensions.Propagators.Tests.csproj
+++ b/test/OpenTelemetry.Extensions.Propagators.Tests/OpenTelemetry.Extensions.Propagators.Tests.csproj
@@ -2,8 +2,7 @@
 
   <PropertyGroup>
     <!-- OmniSharp/VS Code requires TargetFrameworks to be in descending order for IntelliSense and analysis. -->
-    <!-- FIXME(alxbl): Do not build net462 on Mac/*NIX-->
-    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">net7.0;net6.0</TargetFrameworks>
+    <TargetFrameworks Condition="$(TARGET_FRAMEWORK) == ''">net7.0;net6.0;net462</TargetFrameworks>
     <TargetFrameworks Condition="$(TARGET_FRAMEWORK) != ''">$(TARGET_FRAMEWORK)</TargetFrameworks>
 
     <!-- this is temporary. will remove in future PR. -->

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -21,11 +21,10 @@ namespace OpenTelemetry.Metrics.Tests
 {
     public class AggregatorTest
     {
+        private static readonly Meter Meter = new("test.meter", "1.0");
+        private static readonly Instrument Instrument = Meter.CreateCounter<int>("test");
 
-        private static readonly Meter meter = new Meter("test.meter", "1.0");
-        private static readonly Instrument instrument = meter.CreateCounter<int>("test");
-
-        private readonly AggregatorStore aggregatorStore = new(new MetricStreamIdentity(instrument, null), AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024, Metric.DefaultHistogramBounds);
+        private readonly AggregatorStore aggregatorStore = new(new MetricStreamIdentity(Instrument, null), AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024, Metric.DefaultHistogramBounds);
 
         [Fact]
         public void HistogramDistributeToAllBucketsDefault()

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -21,7 +21,7 @@ namespace OpenTelemetry.Metrics.Tests
 {
     public class AggregatorTest
     {
-        private static readonly Meter Meter = new("test.meter", "1.0");
+        private static readonly Meter Meter = new(nameof(AggregatorTest), "1.0");
         private static readonly Instrument Instrument = Meter.CreateCounter<int>("test");
 
         private readonly AggregatorStore aggregatorStore = new(new MetricStreamIdentity(Instrument, null), AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024, Metric.DefaultHistogramBounds);

--- a/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/AggregatorTest.cs
@@ -14,13 +14,18 @@
 // limitations under the License.
 // </copyright>
 
+using System.Diagnostics.Metrics;
 using Xunit;
 
 namespace OpenTelemetry.Metrics.Tests
 {
     public class AggregatorTest
     {
-        private readonly AggregatorStore aggregatorStore = new("test", AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024, Metric.DefaultHistogramBounds);
+
+        private static readonly Meter meter = new Meter("test.meter", "1.0");
+        private static readonly Instrument instrument = meter.CreateCounter<int>("test");
+
+        private readonly AggregatorStore aggregatorStore = new(new MetricStreamIdentity(instrument, null), AggregationType.HistogramWithBuckets, AggregationTemporality.Cumulative, 1024, Metric.DefaultHistogramBounds);
 
         [Fact]
         public void HistogramDistributeToAllBucketsDefault()
@@ -58,7 +63,7 @@ namespace OpenTelemetry.Metrics.Tests
             histogramPoint.Update(10000);
             histogramPoint.Update(10001);
             histogramPoint.Update(10000000);
-            histogramPoint.TakeSnapshot(true);
+            histogramPoint.TakeSnapshot(true, isObserved: false);
 
             var count = histogramPoint.GetHistogramCount();
 
@@ -89,7 +94,7 @@ namespace OpenTelemetry.Metrics.Tests
             histogramPoint.Update(11);
             histogramPoint.Update(19);
 
-            histogramPoint.TakeSnapshot(true);
+            histogramPoint.TakeSnapshot(true, isObserved: false);
 
             var count = histogramPoint.GetHistogramCount();
             var sum = histogramPoint.GetHistogramSum();
@@ -135,7 +140,7 @@ namespace OpenTelemetry.Metrics.Tests
                 histogramPoint.Update(i);
             }
 
-            histogramPoint.TakeSnapshot(true);
+            histogramPoint.TakeSnapshot(true, isObserved: false);
 
             // Assert
             var index = 0;
@@ -167,7 +172,7 @@ namespace OpenTelemetry.Metrics.Tests
             histogramPoint.Update(11);
             histogramPoint.Update(19);
 
-            histogramPoint.TakeSnapshot(true);
+            histogramPoint.TakeSnapshot(true, isObserved: false);
 
             var count = histogramPoint.GetHistogramCount();
             var sum = histogramPoint.GetHistogramSum();

--- a/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MemoryEfficiencyTests.cs
@@ -97,7 +97,6 @@ namespace OpenTelemetry.Metrics.Tests
                 }
 
                 Assert.Equal(2, i);
-
             });
 
             exportedItems.Clear();
@@ -115,7 +114,6 @@ namespace OpenTelemetry.Metrics.Tests
                 }
 
                 Assert.Equal(2, i);
-
             });
 
             measurements.Clear();
@@ -124,13 +122,12 @@ namespace OpenTelemetry.Metrics.Tests
             // Last collect has []. No measurements observed, everything is reclaimed..
             meterProvider.ForceFlush();
             Assert.Empty(exportedItems);
-
         }
 
         // Does this even need to be tested? There's probably some overlap with existing tests.
-        public void Instrument_DataPointsAreNotReclaimed()
-        {
-            // TODO
-        }
+        // public void Instrument_DataPointsAreNotReclaimed()
+        // {
+        //    // TODO
+        // }
     }
 }

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTest.cs
@@ -1,4 +1,4 @@
-// <copyright file="ReclaimDebug.cs" company="OpenTelemetry Authors">
+// <copyright file="MetricPointReclaimTest.cs" company="OpenTelemetry Authors">
 // Copyright The OpenTelemetry Authors
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
@@ -13,7 +13,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 // </copyright>
-using System.Diagnostics;
 using System.Diagnostics.Metrics;
 using OpenTelemetry.Metrics;
 using Xunit;
@@ -26,7 +25,6 @@ namespace OpenTelemetry.Tests.Metrics
 
         private static readonly Meter Meter = new(nameof(MetricPointReclaimTest), "1.0.0");
 
-        // The data used to reproduce the problem.
         private static readonly List<(int, int)> Data = new()
         {
                  (1, 2),
@@ -58,7 +56,6 @@ namespace OpenTelemetry.Tests.Metrics
         [Fact]
         public void Verify_DataPointReclaimLabelConsistency()
         {
-            Random rng = new();
             List<Measurement<int>> measurements = new();
 
             for (int i = 0; i < MeasurementCount; ++i)
@@ -87,22 +84,12 @@ namespace OpenTelemetry.Tests.Metrics
 
             void VerifyLabelsAndValue(Metric metric)
             {
-                if (metric.Name != "gauge" || metric.MeterName != Meter.Name)
-                {
-                    return; // Not the intended instrument.
-                }
-
                 foreach (var datapoint in metric.GetMetricPoints())
                 {
                     var tags = new Dictionary<string, object>();
                     foreach (var tag in datapoint.Tags)
                     {
                         tags.Add(tag.Key, tag.Value);
-                    }
-
-                    if (Data.Count == 0)
-                    {
-                        Debugger.Break();
                     }
 
                     var expected = datapoint.GetGaugeLastValueLong();

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTest.cs
@@ -1,0 +1,124 @@
+// <copyright file="ReclaimDebug.cs" company="OpenTelemetry Authors">
+// Copyright The OpenTelemetry Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+// </copyright>
+using System.Diagnostics;
+using System.Diagnostics.Metrics;
+using OpenTelemetry.Metrics;
+using Xunit;
+
+namespace OpenTelemetry.Tests.Metrics
+{
+    public class MetricPointReclaimTest
+    {
+        private const int MeasurementCount = 10;
+
+        private static readonly Meter Meter = new(nameof(MetricPointReclaimTest), "1.0.0");
+
+        // The data used to reproduce the problem.
+        private static readonly List<(int, int)> Data = new()
+        {
+                 (1, 2),
+                 (2, 7),
+                 (2, 5),
+                 (3, 5),
+                 (4, 5),
+                 (4, 6),
+                 (2, 0),
+                 (2, 1),
+                 (3, 0),
+                 (1, 3),
+                 (1, 1),
+                 (2, 1),
+                 (3, 4),
+                 (2, 5),
+                 (1, 3),
+                 (0, 2),
+                 (2, 4),
+                 (1, 9),
+                 (3, 1),
+                 (4, 9),
+                 (1, 1),
+                 (4, 1),
+                 (4, 4),
+                 (1, 4),
+        };
+
+        [Fact]
+        public void Verify_DataPointReclaimLabelConsistency()
+        {
+            Random rng = new();
+            List<Measurement<int>> measurements = new();
+
+            for (int i = 0; i < MeasurementCount; ++i)
+            {
+                measurements.Add(new(i + 1, new KeyValuePair<string, object>("num", i + 1)));
+            }
+
+            List<Metric> metrics = new();
+            using var meters = Sdk.CreateMeterProviderBuilder()
+            .AddMeter(Meter.Name)
+            .SetMaxMetricPointsPerMetricStream((MeasurementCount / 2) + 1)
+            .AddInMemoryExporter(metrics)
+            .Build();
+
+            var g = Meter.CreateObservableGauge("gauge", () =>
+            {
+                int skip = 0, take = 0;
+                if (Data.Count > 0)
+                {
+                    (skip, take) = Data.ElementAt(0);
+                    Data.RemoveAt(0);
+                }
+
+                return measurements.Skip(skip).Take(take);
+            });
+
+            void VerifyLabelsAndValue(Metric metric)
+            {
+                if (metric.Name != "gauge" || metric.MeterName != Meter.Name)
+                {
+                    return; // Not the intended instrument.
+                }
+
+                foreach (var datapoint in metric.GetMetricPoints())
+                {
+                    var tags = new Dictionary<string, object>();
+                    foreach (var tag in datapoint.Tags)
+                    {
+                        tags.Add(tag.Key, tag.Value);
+                    }
+
+                    if (Data.Count == 0)
+                    {
+                        Debugger.Break();
+                    }
+
+                    var expected = datapoint.GetGaugeLastValueLong();
+                    if (tags.TryGetValue("num", out var result))
+                    {
+                        Assert.Equal(expected, Convert.ToInt64(result));
+                    }
+                }
+            }
+
+            while (Data.Count > 0)
+            {
+                meters.ForceFlush();
+                metrics.ForEach(VerifyLabelsAndValue);
+                metrics.Clear();
+            }
+        }
+    }
+}

--- a/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTest.cs
+++ b/test/OpenTelemetry.Tests/Metrics/MetricPointReclaimTest.cs
@@ -60,7 +60,7 @@ namespace OpenTelemetry.Tests.Metrics
 
             for (int i = 0; i < MeasurementCount; ++i)
             {
-                measurements.Add(new(i + 1, new KeyValuePair<string, object>("num", i + 1)));
+                measurements.Add(new(i + 1, new KeyValuePair<string, object>("num", i + 1), new KeyValuePair<string, object>("aaa", i + 1))); // unsorted.
             }
 
             List<Metric> metrics = new();


### PR DESCRIPTION
Fixes #TODO
Design discussion issue #TODO

## Changes

Based on the understanding that observable instruments are polled on every `Collect` cycle by the export thread, it is possibly to efficiently reuse data points when they have not been polled for two consecutive cycles.

By default, the behavior remains the same until the maximum number of metric points has been reached, after which all stale metric points are added to a free list. Subsequent metric point lookups will use the free list if the point is not already available to re-use an available point.

This preserves the original behavior when the total number of metric points remains under the maximum limit, and offsets the cost of allocating/managing the freelist until it is required.

The implementation works by adding a lazily computed free list in `AggregatorStore` as well as two new `MetricPointStatus`es: `Stale`, `Free`

The algorithm works as follows:
- On Snapshot, observable instruments are marked as `Stale` if not already.
- On Snapshot, when an instrument is marked as `Stale`:
  - If the `freelist` does not exist, nothing is done. The metric point remains Stale and no data is exported
  - If the `freelist` does exist, then the metric point is marked as `Free` and its index is added to `freelist`
- On Update, the metric point is marked as `CollectPending` or `NoCollectPending`, as per usual.
-  When looking up the metric point: 
  - If it exists in the tag lookup, it is used, as per usual.
  - If it does not exist and it cannot be created because the metric point limit has been reached:
    - The free list is computed if it does not exist yet. (`AggregatorStore.BuildFreelistSlow()`)
    - If a free list entry exists, it is re-used for this metric point.
    - If no free list entry exists, then there are no points to be re-used and the metric point is dropped/not reported.
 

## Merge requirement checklist

* [ ] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-dotnet/blob/main/CONTRIBUTING.md) guidelines followed (nullable enabled, static analysis, etc.)
* [x] Unit tests added/updated
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial changes
* [ ] Changes in public API reviewed (if applicable)
