### PR TITLE
chore: run CI on `genetec/*` branches.

### DIFF
--- a/.github/workflows/genetec.yml
+++ b/.github/workflows/genetec.yml
@@ -1,0 +1,37 @@
+name: CI (Genetec)
+
+on:
+  push:
+    branches: [ 'genetec/*' ]
+    paths-ignore:
+    - '**.md'
+  pull_request:
+    branches: [ 'genetec/*' ]
+    paths-ignore:
+    - '**.md'
+
+jobs:
+  build-test:
+    strategy:
+      fail-fast: false  # ensures the entire test matrix is run, even if one permutation fails
+      matrix:
+        os: [ windows-latest, ubuntu-latest ]
+        version: [ net462, net6.0, net7.0 ]
+        exclude:
+        - os: ubuntu-latest
+          version: net462
+
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0 # fetching all
+
+    - name: Install dependencies
+      run: dotnet restore
+
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+
+    - name: Test ${{ matrix.version }}
+      run: dotnet test **/bin/**/${{ matrix.version }}/*.Tests.dll --logger:"console;verbosity=detailed"


### PR DESCRIPTION
This allows to develop outside of `main` and test prior to opening PRs upstream. 

This is an internal commit not meant to be included in upstream pull requests.
